### PR TITLE
[Depsy] Upgrade dependency chai to ^3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "babel-core": "^5.8.24",
     "babel-eslint": "^4.1.1",
     "babel-loader": "^5.3.2",
-    "chai": "^2.3.0",
+    "chai": "^3.4.0",
     "chai-as-promised": "^5.1.0",
     "css-loader": "^0.18.0",
     "ejs": "^2.3.1",


### PR DESCRIPTION
Hi!

A new version was just released of `chai`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded chai to ^3.4.0
#### Changelog:
#### Version 3.4.0

This release improves some confusing error messages, and adds some new assertions. Key points:
- Feature: New assertion: `expect(1).oneOf([1,2,3])` - for asserting that a given value is one of a set.
- Feature: `.include()` (and variants) will now give better error messages for bad object types. Before `expect(undefined).to.include(1)` would say "expected undefined to include 1", now says "object tested must be an array, an object, or a string but undefined given"
- Feature: `.throw()` (and variants) can now better determine the Error types, for example `expect(foo).to.throw(node_assert.AssertionError)` now works.
- Feature: `.closeTo` is now aliased as `.approximately`
- BugFix: `.empty` changes from 3.3.0 have been reverted, as they caused breaking changes to arrays which manually set keys.
### Community Contributions
#### Code Features & Fixes
- `#503` (`https://github.com/chaijs/chai/pull/503`) Checking that argument given to expect is of the right type when using with include. By [`@astorije`](https://github.com/astorije)
- `#446` (`https://github.com/chaijs/chai/pull/446`) Make chai able to cope with AssertionErrors raised from node's assert. By [`@danielbprice`](https://github.com/danielbprice)
- `#527` (`https://github.com/chaijs/chai/pull/527`) Added approximately alias to close to. By [`@danielbprice`](https://github.com/danielbprice)
- `#534` (`https://github.com/chaijs/chai/pull/534`) `expect(inList).to.be.oneOf` assertion. By [`@Droogans`](https://github.com/Droogans)
- `#538` (`https://github.com/chaijs/chai/pull/538`) Revert .empty assertion change from PR `#499`. By [`@tusbar`](https://github.com/tusbar)
#### Documentation fixes
- `#521` (`https://github.com/chaijs/chai/pull/521`) document how the `new Error` type gets detected by the `a`/`an` matcher. By [`@jurko-gospodnetic`](https://github.com/jurko-gospodnetic)
- `#522` (`https://github.com/chaijs/chai/pull/522`) Fixes spelling error "everthing" -> "everything". By [`@austinpray`](https://github.com/austinpray)
- `#529` (`https://github.com/chaijs/chai/pull/529`) Fix assert lengthOf example. By [`@dxuehu`](https://github.com/dxuehu)
- `#533` (`https://github.com/chaijs/chai/pull/533`) Fix typo in README.md. By [`@astorije`](https://github.com/astorije)
#### Version 3.3.0

This release adds some new assertions and fixes some quite important, long standing bugs. Here are the cliff notes:
- Bugfix: Property assertions that fail now show a stack trace!
- Bugfix: If you've used the `frozen`, `sealed` or `extensible` assertions to test primitives (e.g. `expect(1).to.be.frozen`), you may have noticed that in older browsers (ES5) these fail, and in new ones (ES6) they pass. They have now been fixed to consistently pass
- The `assert` interface has been given the following new methods, to align better with other interfaces:, `assert.isAtMost`, `assert.isAtLeast`, `assert.isNotTrue`, `assert.isNotFalse`.
### Community Contributions
#### Code Features & Fixes
- `#494` (`https://github.com/chaijs/chai/pull/494`) Add `assert.isNotTrue` and `assert.isNotFalse`.
  By [`@cezarykluczynski`](https://github.com/cezarykluczynski)
- `#496` (`https://github.com/chaijs/chai/pull/496`) `frozen`/`extensible`/`sealed` assertions behave the same in ES6 and ES5 environments.
  By [`@astorije`](https://github.com/astorije)
- `#499` (`https://github.com/chaijs/chai/pull/499`) Simplify the `.empty` assertion.
  By [`@Daveloper87`](https://github.com/Daveloper87)
- `#500` (`https://github.com/chaijs/chai/pull/500`) Add `assert.isAtMost` and `assert.isAtLeast`.
  By [`@wraithan`](https://github.com/wraithan)
- `#512` (`https://github.com/chaijs/chai/pull/512`) fixed expect('').to.contain('') so it passes. By [`@dereke`](https://github.com/dereke)
- `#514` (`https://github.com/chaijs/chai/pull/514`) Fix stack trace tracking for property assertions.
  By [`@kpdecker`](https://github.com/kpdecker)
#### Documentation fixes
- `#495` (`https://github.com/chaijs/chai/pull/495`) Correct misplaced docs for assertions (`isBelow`, `isAbove`, `isTrue`).
  By [`@cezarykluczynski`](https://github.com/cezarykluczynski)
#### Version 3.2.0

This release fixes a bug with the previous additions in `3.1.0`. `assert.frozen`/`expect().to.be.frozen`/`.should.be.frozen` all accidentally called `Object.isSealed()` instead. Now they correctly call `Object.isFrozen()`.

If you're using these features, please upgrade immediately.

It also adds aliases for a lot of `assert` methods: 
- expect/should..respondTo: respondsTo
- expect/should..satisfy: satisfies
- assert.ok: assert.isOk
- assert.notOk: assert.isNotOk
- assert.extensible: assert.isExtensible
- assert.notExtensible: assert.isNotExtensible
- assert.sealed: assert.isSealed
- assert.notSealed: assert.isNotSealed
- assert.frozen: assert.isFrozen
- assert.notFrozen: assert.isNotFrozen
### Community Contributions
#### Code Features & Fixes
- `#482` (`https://github.com/chaijs/chai/pull/482`) Re-encrypt travis API key 
  By [`@keithamus`](https://github.com/keithamus)
- `#482` (`https://github.com/chaijs/chai/pull/482`) Add respondsTo and satisfies as aliases
  By [`@couchand`](https://github.com/couchand)
- `#485` (`https://github.com/chaijs/chai/pull/485`) Fixing a typo in the `getProperties()` utility
  By [`@jluchiji`](https://github.com/jluchiji)
- `#486` (`https://github.com/chaijs/chai/pull/486`) Added links to contribution guidelines to README
  By [`@jluchiji`](https://github.com/jluchiji)
- `#489` (`https://github.com/chaijs/chai/pull/489`) Various work on aliases
  By [`@astorije`](https://github.com/astorije)
- `#490` (`https://github.com/chaijs/chai/pull/490`) Fix wrong call to the underlying method when checking if an object is frozen
  By [`@astorije`](https://github.com/astorije)
#### Version 3.1.0

This release adds assertions for extensibility/freezing/sealing on objects:

``` js
assert.extensible({});
assert.notExtensible(Object.preventExtensions({}));
expect(Object.preventExtensions({})).to.not.be.extensible;
Object.preventExtensions({}).should.not.be.extensible;

assert.notSealed({});
assert.sealed(Object.seal({}));
expect(Object.seal({})).to.be.sealed;
Object.seal({}).should.be.sealed;

assert.notFrozen({});
assert.frozen(Object.freeze({}));
expect(Object.freeze({})).to.be.frozen;
Object.freeze({}).should.be.frozen;
```

It also adds assertions for checking if a number is NaN:

``` js
assert.isNaN(NaN);
assert.isNotNaN(5);
expect(NaN).to.be.NaN;
expect(5).to.not.be.NaN;
NaN.should.be.NaN;
5.should.not.be.NaN;
```
### Community Contributions
#### Code Features & Fixes
- `#480` (`https://github.com/chaijs/chai/pull/480`) Added tests and expectations for NaN
  By [`@bradcypert`](https://github.com/bradcypert)
- `#479` (`https://github.com/chaijs/chai/pull/479`) Assertions to test if objects are extensible/sealed/frozen.
  By [`@matthewlucock`](https://github.com/matthewlucock)
- `#468` (`https://github.com/chaijs/chai/pull/468`) Remove moot `version` property from bower.json.
  By [`@kkirsche`](https://github.com/kkirsche)
#### Version 3.0.0

This release contains some small breaking changes. Most people are unlikely to
notice them - but here are the breaking changes:
- Switched from "Component" builds to "Browserify" builds for Browsers. If
  you're using RequireJS with Chai, you might notice a change (chai used to
  be a global, now it won't be - instead you'll have to `require` it).
- `.has.property('foo', undefined)` will now specifically test to make sure
  that the value `'foo'` is actually undefined - before it simply tested that
  the key existed (but could have a value).
- `.to.be.a('type')` has changed to support more types, including ES6 types
  such as `'promise'`, `'symbol'`, `'float32array'` etc, this also means using
  ES6's `Symbol.toStringTag` affects the behaviour `.to.be.a()`. In addition to
  this, Errors have the type of `'error'`.
- `assert.ifError()` now follows Node's `assert.ifError()` behaviour - in other
  words, if the first argument is truthy, it'll throw it.
- ReleaseNotes.md is no longer maintained, see the [Github Releases Page](https://github.com/chaijs/chai/releases) instead.
- History.md is no longer maintained, see the [Github Commit Log](`https://github.com/chaijs/chai/commits/master`) instead.
### Community Contributions
#### Code Features & Fixes
- `#403` (`https://github.com/chaijs/chai/pull/403`) `assert.ifError()` behaves like Node.js: it throws if the first argument is present.
  By [`@cjqed`](https://github.com/cjqed)
- `#419` (`https://github.com/chaijs/chai/pull/419`) [assertion-error](https://github.com/chaijs/assertion-error) bumped to `^1.0.1`
  By [`@keithamus`](https://github.com/keithamus) (special thanks to [`@simonzack`](https://github.com/simonzack) for his work on assertion-error)
- `#421` (`https://github.com/chaijs/chai/pull/421`) replace type.js with type-detect module.
  By [`@Charminbear`](https://github.com/Charminbear)
- `#439` (`https://github.com/chaijs/chai/pull/439`) Add `.matches()` as alias for `.match()`.
  By [`@thejameskyle`](https://github.com/thejameskyle)
- `#451` (`https://github.com/chaijs/chai/pull/451`) Switch to using Browserify for the build system.
  By [`@csnover`](https://github.com/csnover)
- `#452` (`https://github.com/chaijs/chai/pull/452`) `.property('foo', undefined)` now actually checks to see if `obj.foo === undefined` (before it did not).
  By [`@onefifth`](https://github.com/onefifth)
- `#460` (`https://github.com/chaijs/chai/pull/460`) Automate release process as much as possible
  By [`@keithamus`](https://github.com/keithamus)
#### Documentation fixes
- `#397` (`https://github.com/chaijs/chai/pull/397`) Improve docs for `.assert()`
  By [`@astorije`](https://github.com/astorije)
- `#401` (`https://github.com/chaijs/chai/pull/401`) Add some badges to the Readme.
  By [`@keithamus`](https://github.com/keithamus)
- `#424` (`https://github.com/chaijs/chai/pull/424`) Fix typo in docs for `.keys()`
  By [`@astorije`](https://github.com/astorije)
- `#429` (`https://github.com/chaijs/chai/pull/429`) Deprecate `.length(n)` from the docs - use `.lengthOf(n)` instead.
  By [`@valscion`](https://github.com/valscion)
- `#444` (`https://github.com/chaijs/chai/pull/444`) Change `.length(n)` examples to `.lengthOf(n)` instead.
  By [`@keithamus`](https://github.com/keithamus)
- `#458` (`https://github.com/chaijs/chai/pull/458`) Remove stray character in `assert.notInclude` docs
  By [`@BinaryMuse`](https://github.com/BinaryMuse)
