### PR TITLE
[Depsy] Upgrade dependency babel-core to ^6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "superagent": "^1.2.0"
   },
   "devDependencies": {
-    "babel-core": "^5.8.24",
+    "babel-core": "^6.0.1",
     "babel-eslint": "^4.1.1",
     "babel-loader": "^5.3.2",
     "chai": "^2.3.0",


### PR DESCRIPTION
Hi!

A new version was just released of `babel-core`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel-core to ^6.0.1
