### PR TITLE
[Depsy] Upgrade dependency bluebird to ^3.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "ansi_up": "^1.3.0",
     "babel": "^5.4.3",
-    "bluebird": "^2.9.25",
+    "bluebird": "^3.0.4",
     "camelcase": "^1.2.1",
     "flux": "^2.0.3",
     "immutable": "^3.7.3",


### PR DESCRIPTION
Hi!

A new version was just released of `bluebird`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded bluebird to ^3.0.4
#### Changelog:
#### Version 3.0.4

Bugfixes:
- The stack trace for [forgotten return warnings](http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-none-were-returned-from-it) is more useful now.
#### Version 3.0.3

Bugfixes:
- 3rd party libraries rejecting promises with non-errors no longer causes warnings
- When `NODE_ENV` environment variable is `"development"` setting `BLUEBIRD_DEBUG` environment variable to `0` can now be used to disable debug mode
#### Version 3.0.1

See [New in 3.0](http://bluebirdjs.com/docs/new-in-bluebird-3.html).
#### Version 3.0.0

See [New in 3.0](http://bluebirdjs.com/docs/new-in-bluebird-3.html).
#### Version 2.9.9

Bugfixes:
- Fix `TypeError: Cannot assign to read only property 'length'` when jsdom has declared a read-only length for all objects to inherit.
#### Version 2.9.8

Bugfixes:
- Fix regression introduced in 2.9.7 where promisify didn't properly dynamically look up methods on `this`
#### Version 2.9.7

Bugfixes:
- Fix `promisify` not retaining custom properties of the function. This enables promisifying the `"request"` module's export function and its methods at the same time.
- Fix `promisifyAll` methods being dependent on `this` when they are not originally dependent on `this`. This enables e.g. passing promisified `fs` functions directly as callbacks without having to bind them to `fs`.
- Fix `process.nextTick` being used over `setImmediate` in node.
#### Version 2.9.6

Bugfixes:
- Node environment detection can no longer be fooled
#### Version 2.9.5

Misc:
- Warn when [`.then()`](.) is passed non-functions
#### Version 2.9.4

Bugfixes:
- Fix [.timeout()](.) not calling `clearTimeout` with the proper handle in node causing the process to wait for unneeded timeout. This was a regression introduced in 2.9.1.
