### PR TITLE
[Depsy] Upgrade dependency babel-loader to ^6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "babel-core": "^5.8.24",
     "babel-eslint": "^4.1.1",
-    "babel-loader": "^6.0.1",
+    "babel-loader": "^6.1.0",
     "chai": "^2.3.0",
     "chai-as-promised": "^5.1.0",
     "css-loader": "^0.18.0",


### PR DESCRIPTION
Hi!

A new version was just released of `babel-loader`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel-loader to ^6.0.1
