### PR TITLE
[Depsy] Upgrade dependency css-loader to ^0.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-loader": "^5.3.2",
     "chai": "^2.3.0",
     "chai-as-promised": "^5.1.0",
-    "css-loader": "^0.18.0",
+    "css-loader": "^0.22.0",
     "ejs": "^2.3.1",
     "eslint": "*",
     "eslint-config-airbnb": "*",


### PR DESCRIPTION
Hi!

A new version was just released of `css-loader`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded css-loader to ^0.22.0
