### PR TITLE
[Depsy] Upgrade dependency react-mixin to ^3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "moment": "^2.10.3",
     "nib": "^1.1.0",
     "react": "^0.13.3",
-    "react-mixin": "^1.3.1",
+    "react-mixin": "^3.0.2",
     "react-router": "^0.13.3",
     "snake-case": "^1.1.1",
     "stylus": "^0.51.1",


### PR DESCRIPTION
Hi!

A new version was just released of `react-mixin`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded react-mixin to ^3.0.2
