### PR TITLE
[Depsy] Upgrade dependency webpack to ^1.12.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "style-loader": "^0.12.3",
     "stylus-loader": "^1.3.0",
     "url-loader": "^0.5.6",
-    "webpack": "^1.12.1",
+    "webpack": "^1.12.3",
     "webpack-dev-middleware": "^1.2.0"
   }
 }


### PR DESCRIPTION
Hi!

A new version was just released of `webpack`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded webpack to ^1.12.3
