### PR TITLE
[Depsy] Upgrade dependency babel to ^6.1.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/frigg/frigg-frontend#readme",
   "dependencies": {
     "ansi_up": "^1.3.0",
-    "babel": "^6.1.5",
+    "babel": "^6.1.18",
     "bluebird": "^2.9.25",
     "camelcase": "^1.2.1",
     "flux": "^2.0.3",


### PR DESCRIPTION
Hi!

A new version was just released of `babel`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel to ^6.1.5
