### PR TITLE
[Depsy] Upgrade dependency babel-core to ^6.3.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "superagent": "^1.2.0"
   },
   "devDependencies": {
-    "babel-core": "^6.3.2",
+    "babel-core": "^6.3.13",
     "babel-eslint": "^4.1.1",
     "babel-loader": "^5.3.2",
     "chai": "^2.3.0",


### PR DESCRIPTION
Hi!

A new version was just released of `babel-core`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel-core to ^6.2.0
