### PR TITLE
[Depsy] Upgrade dependency bluebird to ^3.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/frigg/frigg-frontend#readme",
   "dependencies": {
     "babel": "^5.4.3",
-    "bluebird": "^2.9.25",
+    "bluebird": "^3.0.6",
     "camelcase": "^1.2.1",
     "emojis": "^1.0.7",
     "eventemitter3": "^1.1.1",


### PR DESCRIPTION
Hi!

A new version was just released of `bluebird`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded bluebird to ^3.0.6
#### Changelog:
#### Version 3.0.6

Features:
- feature

Bugfixes:
- Fix [.timeout()](.) not cancelling parent ([`#891`](.))
- Fix long stack traces when using [Promise.resolve()](.) ([`#861`](.))
- Fix [Promise.config()](.) not disabling long stack traces when passing `longStackTraces: false` ([`#897`](.))
#### Version 3.0.5

Bugfixes:
- Added [forgotten return warnings](http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-none-were-returned-from-it)  to [Promise.try](.) and [Promise.method](.)
#### Version 3.0.4

Bugfixes:
- The stack trace for [forgotten return warnings](http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-none-were-returned-from-it) is more useful now.
#### Version 3.0.3

Bugfixes:
- 3rd party libraries rejecting promises with non-errors no longer causes warnings
- When `NODE_ENV` environment variable is `"development"` setting `BLUEBIRD_DEBUG` environment variable to `0` can now be used to disable debug mode
#### Version 3.0.1

See [New in 3.0](http://bluebirdjs.com/docs/new-in-bluebird-3.html).
#### Version 3.0.0

See [New in 3.0](http://bluebirdjs.com/docs/new-in-bluebird-3.html).
